### PR TITLE
Remove title and subtitle from header

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,8 +14,6 @@
         <header class="app-header">
             <div class="header-content">
                 <div class="header-title">
-                    <h1>Course Materials Assistant</h1>
-                    <p class="subtitle">Ask questions about courses, instructors, and content</p>
                 </div>
                 <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme" title="Toggle between light and dark theme">
                     <svg class="theme-icon theme-icon-sun" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION
Fixes #2 by removing the 'Course Materials Assistant' title and 'Ask questions about courses, instructors, and content' subtitle from the header as requested.

Generated with [Claude Code](https://claude.ai/code)